### PR TITLE
Click click

### DIFF
--- a/pomodoro/index.html
+++ b/pomodoro/index.html
@@ -50,6 +50,11 @@
       <i class="fas fa-arrow-left"></i> Back
     </a>
 
+    <!-- Info Navigation Link -->
+    <a class="pomodoro-back-link" href="info.html" style="left: auto; right: 30px;">
+      <i class="fas fa-info-circle"></i> Info
+    </a>
+
     <!-- Main Timer Container -->
     <div class="pomodoro-container">
       <!-- Title -->


### PR DESCRIPTION
Made a button at top corner if people don't find out they can click Pomodoro title to go to info page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an “Info” link to the Pomodoro page header next to the Back link. The link includes an info icon, is right-aligned for visibility, and directs to the information page. Improves discoverability of help/resources on both desktop and mobile. No changes to timer or task functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->